### PR TITLE
Adding LAS (well log) files to the registry

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -284,3 +284,5 @@ add_format(format"MetaImage", "ObjectType", ".mhd", [:MetaImageFormat])
 add_format(format"vegalite", (), [".vegalite"], [:VegaLite])
 
 add_format(format"FCS", "FCS", [".fcs"], [:FCSFiles])
+
+add_format(format"LAS", (), [".las",".LAS"], [:WellLogIO])


### PR DESCRIPTION
Hi, I am proposing an addition to the registry. This addition is for the LAS file format which is a text based format without magic bytes.
The Log ASCII Standard (LAS) files are used for borehole data such as geophysical, geological, or petrophysical logs in oil and gas wells.
The LAS file specification has been published by [the Canadian Well Logging Society] (http://www.cwls.org/las/)
I am writing a LAS package called WellLogIO.jl that will use this file format.

Note this is not for LiDAR data (also called "LAS files").